### PR TITLE
move adapter.js to Qiniu CDN

### DIFF
--- a/src/content/capture/canvas-pc/index.html
+++ b/src/content/capture/canvas-pc/index.html
@@ -74,7 +74,7 @@
 <script src="../../../js/third_party/webgl_teapot/teapot-streams.js"></script>
 <script src="../../../js/third_party/webgl_teapot/demo.js"></script>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 
 <script src="js/main.js" async></script>
 

--- a/src/content/capture/canvas-pc/index.html
+++ b/src/content/capture/canvas-pc/index.html
@@ -74,7 +74,7 @@
 <script src="../../../js/third_party/webgl_teapot/teapot-streams.js"></script>
 <script src="../../../js/third_party/webgl_teapot/demo.js"></script>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 
 <script src="js/main.js" async></script>
 

--- a/src/content/capture/canvas-record/index.html
+++ b/src/content/capture/canvas-record/index.html
@@ -77,7 +77,7 @@
 <script src="../../../js/third_party/webgl_teapot/demo.js"></script>
 
 <!-- include adapter for srcObject shim -->
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js"></script>
 <script src="../../../js/lib/ga.js"></script>
 

--- a/src/content/capture/canvas-record/index.html
+++ b/src/content/capture/canvas-record/index.html
@@ -77,7 +77,7 @@
 <script src="../../../js/third_party/webgl_teapot/demo.js"></script>
 
 <!-- include adapter for srcObject shim -->
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js"></script>
 <script src="../../../js/lib/ga.js"></script>
 

--- a/src/content/capture/video-contenthint/index.html
+++ b/src/content/capture/video-contenthint/index.html
@@ -79,7 +79,7 @@
 
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/capture/video-contenthint/index.html
+++ b/src/content/capture/video-contenthint/index.html
@@ -79,7 +79,7 @@
 
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/capture/video-pc/index.html
+++ b/src/content/capture/video-pc/index.html
@@ -65,7 +65,7 @@
 
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/capture/video-pc/index.html
+++ b/src/content/capture/video-pc/index.html
@@ -65,7 +65,7 @@
 
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/datachannel/basic/index.html
+++ b/src/content/datachannel/basic/index.html
@@ -67,7 +67,7 @@
        title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/datachannel/basic/index.html
+++ b/src/content/datachannel/basic/index.html
@@ -67,7 +67,7 @@
        title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/datachannel/datatransfer/index.html
+++ b/src/content/datachannel/datatransfer/index.html
@@ -89,7 +89,7 @@
        title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/datachannel/datatransfer/index.html
+++ b/src/content/datachannel/datatransfer/index.html
@@ -89,7 +89,7 @@
        title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/datachannel/filetransfer/index.html
+++ b/src/content/datachannel/filetransfer/index.html
@@ -84,7 +84,7 @@
     <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/datachannel/filetransfer" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
   </div>
 
-  <script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+  <script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
   <script src="js/main.js"></script>
 
   <script src="../../../js/lib/ga.js"></script>

--- a/src/content/datachannel/filetransfer/index.html
+++ b/src/content/datachannel/filetransfer/index.html
@@ -84,7 +84,7 @@
     <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/datachannel/filetransfer" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
   </div>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
   <script src="js/main.js"></script>
 
   <script src="../../../js/lib/ga.js"></script>

--- a/src/content/datachannel/messaging/index.html
+++ b/src/content/datachannel/messaging/index.html
@@ -28,7 +28,7 @@
     <link rel="stylesheet" href="main.css"/>
 
     <script src="https://unpkg.com/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
-    <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+    <script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
     <script src="main.js" type="module"></script>
 
 </head>

--- a/src/content/datachannel/messaging/index.html
+++ b/src/content/datachannel/messaging/index.html
@@ -28,7 +28,7 @@
     <link rel="stylesheet" href="main.css"/>
 
     <script src="https://unpkg.com/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
-    <script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+    <script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
     <script src="main.js" type="module"></script>
 
 </head>

--- a/src/content/devices/input-output/index.html
+++ b/src/content/devices/input-output/index.html
@@ -74,7 +74,7 @@
        title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/devices/input-output/index.html
+++ b/src/content/devices/input-output/index.html
@@ -74,7 +74,7 @@
        title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/devices/multi/index.html
+++ b/src/content/devices/multi/index.html
@@ -89,7 +89,7 @@
        title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/devices/multi/index.html
+++ b/src/content/devices/multi/index.html
@@ -89,7 +89,7 @@
        title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/getusermedia/audio/index.html
+++ b/src/content/getusermedia/audio/index.html
@@ -52,7 +52,7 @@
 
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js"></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/getusermedia/audio/index.html
+++ b/src/content/getusermedia/audio/index.html
@@ -52,7 +52,7 @@
 
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js"></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/getusermedia/canvas/index.html
+++ b/src/content/getusermedia/canvas/index.html
@@ -49,7 +49,7 @@
 
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js" async></script>
 <script src="../../../js/lib/ga.js"></script>
 

--- a/src/content/getusermedia/canvas/index.html
+++ b/src/content/getusermedia/canvas/index.html
@@ -49,7 +49,7 @@
 
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js" async></script>
 <script src="../../../js/lib/ga.js"></script>
 

--- a/src/content/getusermedia/filter/index.html
+++ b/src/content/getusermedia/filter/index.html
@@ -94,7 +94,7 @@
        title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/getusermedia/filter/index.html
+++ b/src/content/getusermedia/filter/index.html
@@ -94,7 +94,7 @@
        title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/getusermedia/gum/index.html
+++ b/src/content/getusermedia/gum/index.html
@@ -50,7 +50,7 @@
        title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js"></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/getusermedia/gum/index.html
+++ b/src/content/getusermedia/gum/index.html
@@ -50,7 +50,7 @@
        title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js"></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/getusermedia/record/index.html
+++ b/src/content/getusermedia/record/index.html
@@ -65,7 +65,7 @@
 </div>
 
 <!-- include adapter for srcObject shim -->
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js" async></script>
 <script src="../../../js/lib/ga.js"></script>
 

--- a/src/content/getusermedia/record/index.html
+++ b/src/content/getusermedia/record/index.html
@@ -65,7 +65,7 @@
 </div>
 
 <!-- include adapter for srcObject shim -->
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js" async></script>
 <script src="../../../js/lib/ga.js"></script>
 

--- a/src/content/getusermedia/resolution/index.html
+++ b/src/content/getusermedia/resolution/index.html
@@ -110,7 +110,7 @@
        title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/getusermedia/resolution/index.html
+++ b/src/content/getusermedia/resolution/index.html
@@ -110,7 +110,7 @@
        title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/getusermedia/volume/index.html
+++ b/src/content/getusermedia/volume/index.html
@@ -69,7 +69,7 @@
 </div>
 
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/soundmeter.js"></script>
 <script src="js/main.js" async></script>
 

--- a/src/content/getusermedia/volume/index.html
+++ b/src/content/getusermedia/volume/index.html
@@ -69,7 +69,7 @@
 </div>
 
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/soundmeter.js"></script>
 <script src="js/main.js" async></script>
 

--- a/src/content/peerconnection/audio/index.html
+++ b/src/content/peerconnection/audio/index.html
@@ -91,7 +91,7 @@
     </tr>
 </table>
 <hr>
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js"></script>
 <script src="../../../js/third_party/graph.js"></script>
 

--- a/src/content/peerconnection/audio/index.html
+++ b/src/content/peerconnection/audio/index.html
@@ -91,7 +91,7 @@
     </tr>
 </table>
 <hr>
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js"></script>
 <script src="../../../js/third_party/graph.js"></script>
 

--- a/src/content/peerconnection/bandwidth/index.html
+++ b/src/content/peerconnection/bandwidth/index.html
@@ -68,7 +68,7 @@
 
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js" async></script>
 <script src="../../../js/third_party/graph.js"></script>
 

--- a/src/content/peerconnection/bandwidth/index.html
+++ b/src/content/peerconnection/bandwidth/index.html
@@ -68,7 +68,7 @@
 
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js" async></script>
 <script src="../../../js/third_party/graph.js"></script>
 

--- a/src/content/peerconnection/change-codecs/index.html
+++ b/src/content/peerconnection/change-codecs/index.html
@@ -70,7 +70,7 @@
 
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/change-codecs/index.html
+++ b/src/content/peerconnection/change-codecs/index.html
@@ -70,7 +70,7 @@
 
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/constraints/index.html
+++ b/src/content/peerconnection/constraints/index.html
@@ -110,7 +110,7 @@
 
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js" async></script>
 <script src="../../../js/lib/ga.js"></script>
 

--- a/src/content/peerconnection/constraints/index.html
+++ b/src/content/peerconnection/constraints/index.html
@@ -110,7 +110,7 @@
 
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js" async></script>
 <script src="../../../js/lib/ga.js"></script>
 

--- a/src/content/peerconnection/create-offer/index.html
+++ b/src/content/peerconnection/create-offer/index.html
@@ -71,7 +71,7 @@
 
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/create-offer/index.html
+++ b/src/content/peerconnection/create-offer/index.html
@@ -71,7 +71,7 @@
 
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/dtmf/index.html
+++ b/src/content/peerconnection/dtmf/index.html
@@ -100,7 +100,7 @@
 
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js" async></script>
 <script src="../../../js/lib/ga.js"></script>
 

--- a/src/content/peerconnection/dtmf/index.html
+++ b/src/content/peerconnection/dtmf/index.html
@@ -100,7 +100,7 @@
 
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js" async></script>
 <script src="../../../js/lib/ga.js"></script>
 

--- a/src/content/peerconnection/endtoend-encryption/index.html
+++ b/src/content/peerconnection/endtoend-encryption/index.html
@@ -67,7 +67,7 @@
 
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/videopipe.js"></script>
 <script src="js/main.js" async></script>
 

--- a/src/content/peerconnection/endtoend-encryption/index.html
+++ b/src/content/peerconnection/endtoend-encryption/index.html
@@ -67,7 +67,7 @@
 
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/videopipe.js"></script>
 <script src="js/main.js" async></script>
 

--- a/src/content/peerconnection/multiple-relay/index.html
+++ b/src/content/peerconnection/multiple-relay/index.html
@@ -57,7 +57,7 @@
 
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="../../../js/videopipe.js"></script>
 <script src="js/main.js" async></script>
 

--- a/src/content/peerconnection/multiple-relay/index.html
+++ b/src/content/peerconnection/multiple-relay/index.html
@@ -57,7 +57,7 @@
 
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="../../../js/videopipe.js"></script>
 <script src="js/main.js" async></script>
 

--- a/src/content/peerconnection/multiple/index.html
+++ b/src/content/peerconnection/multiple/index.html
@@ -58,7 +58,7 @@
 
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/multiple/index.html
+++ b/src/content/peerconnection/multiple/index.html
@@ -58,7 +58,7 @@
 
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/munge-sdp/index.html
+++ b/src/content/peerconnection/munge-sdp/index.html
@@ -88,7 +88,7 @@
        title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js"></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/munge-sdp/index.html
+++ b/src/content/peerconnection/munge-sdp/index.html
@@ -88,7 +88,7 @@
        title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js"></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/old-new-stats/index.html
+++ b/src/content/peerconnection/old-new-stats/index.html
@@ -105,7 +105,7 @@
 
   </div>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
   <script src="js/main.js"></script>
   <script src="../../../js/lib/ga.js"></script>
 

--- a/src/content/peerconnection/old-new-stats/index.html
+++ b/src/content/peerconnection/old-new-stats/index.html
@@ -105,7 +105,7 @@
 
   </div>
 
-  <script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+  <script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
   <script src="js/main.js"></script>
   <script src="../../../js/lib/ga.js"></script>
 

--- a/src/content/peerconnection/pc1/index.html
+++ b/src/content/peerconnection/pc1/index.html
@@ -73,7 +73,7 @@
 
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/pc1/index.html
+++ b/src/content/peerconnection/pc1/index.html
@@ -73,7 +73,7 @@
 
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/pr-answer/index.html
+++ b/src/content/peerconnection/pr-answer/index.html
@@ -51,7 +51,7 @@
     <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/peerconnection/pr-answer" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
 
 </div>
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js" async></script>
 <script src="../../../js/lib/ga.js"></script>
 </body>

--- a/src/content/peerconnection/pr-answer/index.html
+++ b/src/content/peerconnection/pr-answer/index.html
@@ -51,7 +51,7 @@
     <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/peerconnection/pr-answer" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
 
 </div>
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js" async></script>
 <script src="../../../js/lib/ga.js"></script>
 </body>

--- a/src/content/peerconnection/restart-ice/index.html
+++ b/src/content/peerconnection/restart-ice/index.html
@@ -70,7 +70,7 @@
 
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/restart-ice/index.html
+++ b/src/content/peerconnection/restart-ice/index.html
@@ -70,7 +70,7 @@
 
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/states/index.html
+++ b/src/content/peerconnection/states/index.html
@@ -86,7 +86,7 @@
 
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/states/index.html
+++ b/src/content/peerconnection/states/index.html
@@ -86,7 +86,7 @@
 
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/trickle-ice/index.html
+++ b/src/content/peerconnection/trickle-ice/index.html
@@ -138,7 +138,7 @@
        title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/trickle-ice/index.html
+++ b/src/content/peerconnection/trickle-ice/index.html
@@ -138,7 +138,7 @@
        title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/upgrade/index.html
+++ b/src/content/peerconnection/upgrade/index.html
@@ -59,7 +59,7 @@
 
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/upgrade/index.html
+++ b/src/content/peerconnection/upgrade/index.html
@@ -59,7 +59,7 @@
 
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/video-analyzer/index.html
+++ b/src/content/peerconnection/video-analyzer/index.html
@@ -69,7 +69,7 @@
 
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/video-analyzer/index.html
+++ b/src/content/peerconnection/video-analyzer/index.html
@@ -69,7 +69,7 @@
 
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/webaudio-input/index.html
+++ b/src/content/peerconnection/webaudio-input/index.html
@@ -89,7 +89,7 @@
 
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="js/webaudioextended.js"></script>
 <script src="js/main.js" async></script>
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/webaudio-input/index.html
+++ b/src/content/peerconnection/webaudio-input/index.html
@@ -89,7 +89,7 @@
 
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="js/webaudioextended.js"></script>
 <script src="js/main.js" async></script>
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/webaudio-output/index.html
+++ b/src/content/peerconnection/webaudio-output/index.html
@@ -61,7 +61,7 @@
 
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
 <script src="../../../js/third_party/streamvisualizer.js"></script>
 <script src="js/main.js" async></script>
 

--- a/src/content/peerconnection/webaudio-output/index.html
+++ b/src/content/peerconnection/webaudio-output/index.html
@@ -61,7 +61,7 @@
 
 </div>
 
-<script src="http://cdn.staticfile.org/webrtc-adapter/7.4.0/adapter.js"></script>
+<script src="https://demo-qnrtc-files.qnsdk.com/webrtc-adapter-latest.js"></script>
 <script src="../../../js/third_party/streamvisualizer.js"></script>
 <script src="js/main.js" async></script>
 


### PR DESCRIPTION
**Description**
将adapter.js的引用地址改为七牛CDN的地址。

**Purpose**
部分客户可能无法访问外网，不能加载adapter.js导致检测工具出现非预期表现。